### PR TITLE
kernel: Fix modules path generated in modules.dep

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -250,7 +250,7 @@ INSTALLED_KERNEL_MODULES: depmod-host
 			for f in $$modules; do \
 				$(KERNEL_TOOLCHAIN_PATH)strip --strip-unneeded $$f; \
 			done; \
-			($(call build-image-kernel-modules,$$modules,$(KERNEL_MODULES_OUT),$(KERNEL_MODULE_MOUNTPOINT),$(KERNEL_DEPMOD_STAGING_DIR))); \
+			($(call build-image-kernel-modules,$$modules,$(KERNEL_MODULES_OUT),$(KERNEL_MODULE_MOUNTPOINT)/,$(KERNEL_DEPMOD_STAGING_DIR))); \
 		fi
 
 $(TARGET_KERNEL_MODULES): TARGET_KERNEL_BINARIES


### PR DESCRIPTION
This patch fixes the error generated path of modules in modules.dep.

Tested on Redmi Note 5(whyred).

Before:
/vendorlib/modules/test-iosched.ko:
/vendorlib/modules/mpq-adapter.ko:
/vendorlib/modules/ufs_test.ko: /vendorlib/modules/test-iosched.ko
/vendorlib/modules/rdbg.ko:
/vendorlib/modules/br_netfilter.ko:
/vendorlib/modules/gspca_main.ko:
/vendorlib/modules/mpq-dmx-hw-plugin.ko: /vendorlib/modules/mpq-adapter.ko

After:
/vendor/lib/modules/test-iosched.ko:
/vendor/lib/modules/mpq-adapter.ko:
/vendor/lib/modules/ufs_test.ko: /vendor/lib/modules/test-iosched.ko
/vendor/lib/modules/rdbg.ko:
/vendor/lib/modules/br_netfilter.ko:
/vendor/lib/modules/gspca_main.ko:
/vendor/lib/modules/mpq-dmx-hw-plugin.ko: /vendor/lib/modules/mpq-adapter.ko

Change-Id: I84d51f4c418fda0d99890db0fd5d976c42f54295