### PR TITLE
Whitelist permissions under legacy package names

### DIFF
--- a/config/permissions/privapp-permissions-cm-legacy.xml
+++ b/config/permissions/privapp-permissions-cm-legacy.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<permissions>
+    <privapp-permissions package="com.cyanogenmod.eleven">
+        <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
+    </privapp-permissions>
+
+    <privapp-permissions package="org.cyanogenmod.cmsettings">
+        <permission name="android.permission.MANAGE_USERS"/>
+    </privapp-permissions>
+
+    <privapp-permissions package="org.cyanogenmod.snap">
+        <permission name="android.permission.PREVENT_POWER_KEY"/>
+        <permission name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS"/>
+        <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
+    </privapp-permissions>
+
+</permissions>


### PR DESCRIPTION
The lack of these whitelisted permissions causes a bootloop
when upgrading from earlier OS versions on devices that enforce
the whitelist.

Change-Id: I76b8fad5f0c49a7d008d19e7a116b5f19c75f739